### PR TITLE
initialize index column flag in to_csv()

### DIFF
--- a/simpledbf/simpledbf.py
+++ b/simpledbf/simpledbf.py
@@ -144,6 +144,8 @@ class DbfBase(object):
             Write out a header line with the column names. Default is True. 
         '''
         self._na_set(na)
+        # set index column; this is only True when used with to_textsql()
+        self._idx = False
         csv = codecs.open(csvname, 'a', encoding=self._enc)
         if header:
             column_line = ','.join(self.columns)


### PR DESCRIPTION
This fixes a bug that occurs when `to_csv()` is used on its own. The index column flag `_idx` (introduced [here](https://github.com/sarasafavi/simpledbf/commit/7c521c53f8284c6fd8fe93f265600576d95a700c)) works great as long as `to_csv()` is called from within `to_textsql()` (because the flag's set to True from there), but if you call `to_csv()` in isolation it throws an AttributeError.
